### PR TITLE
PR: correction on offset after resubmit form

### DIFF
--- a/src/public/html/index.html
+++ b/src/public/html/index.html
@@ -51,7 +51,4 @@
 <script type="module" src="../js/index.js"></script>
 <script type="text/javascript" src="../js/background-animation.js"></script>
 <script type="text/javascript" src="../js/currency/mask-currency.js"></script>
-<script type="text/javascript">
-   
-</script>
 </html>

--- a/src/public/js/countryPage.js
+++ b/src/public/js/countryPage.js
@@ -159,7 +159,7 @@ socket.on('updateCountryConfig', (countries) => {
   // update countries information
   listCountries = countries;
   // display on the screen the new configuration
-  displayCountry(offSetInstance, countries);
+  displayCountry(offSetInstance + offSetController, countries);
 });
 
 // When socket listen an event to update the value of offset of controller


### PR DESCRIPTION
Correção no envio do deslocamento após reenviar o formulário. Essa melhoria faz com que o deslocamento utilize como base o valor que já existia anteriormente, dessa forma, o usuário permanece no país em que estava visualizando e não precisa realizar toda a navegação de volta.